### PR TITLE
copy for sealed hierarchies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ _When the author figures out how to upload the artifact to Maven, instructions o
   - [Mutable `copy`](#mutable-copy)
   - [Mapping `copyMap`](#mapping-copymap)
   - [Value class `copy`](#value-class-copy)
+  - [`copy` for hierarchies](#copy-for-hierarchies)
 - [Using KopyKat in your project](#using-kopykat-in-your-project)
   - [Customizing the generation](#customizing-the-generation)
 - [What about optics?](#what-about-optics)
@@ -77,6 +78,23 @@ val a1 = Age(1)
 val a2 = a1.copy { it + 1 }
 ```
 
+### `copy` for hierarchies
+
+KopyKat also works with sealed hierarchies. It generates regular `copy`, `copyMap`, and mutable `copy` for the common properties, which ought to be declared in the parent class.
+
+```kotlin
+abstract sealed class User(open val name: String)
+data class Person(override val name: String, val age: Int): User(name)
+data class Company(override val name: String, val address: String): User(name)
+```
+
+This means that the following code works directly, without requiring an intermediate `when`.
+
+```kotlin
+fun User.takeOver() = copy { name = "Me" }
+```
+
+
 ## Using KopyKat in your project
 
 > This [demo project](https://github.com/serras/kopykat-demo) showcases the use of KopyKat alongside [version catalogs](https://docs.gradle.org/7.0-rc-1/release-notes.html#centralized-versions).
@@ -120,6 +138,7 @@ ksp {
   arg("mutableCopy", "true")
   arg("copyMap", "false")
   arg("valueCopy", "true")
+  arg("hierarchyCopy", "true")
 }
 ```
 

--- a/ksp/src/main/kotlin/fp/serrano/kopykat/KopyKatOptions.kt
+++ b/ksp/src/main/kotlin/fp/serrano/kopykat/KopyKatOptions.kt
@@ -3,14 +3,16 @@ package fp.serrano.kopykat
 internal data class KopyKatOptions(
   val copyMap: Boolean,
   val mutableCopy: Boolean,
-  val valueCopy: Boolean
+  val valueCopy: Boolean,
+  val hierarchyCopy: Boolean
 ) {
   companion object {
     fun fromKspOptions(options: Map<String, String>) =
       KopyKatOptions(
         copyMap = options.parseBoolOrTrue("copyMap"),
         mutableCopy = options.parseBoolOrTrue("mutableCopy"),
-        valueCopy = options.parseBoolOrTrue("valueCopy")
+        valueCopy = options.parseBoolOrTrue("valueCopy"),
+        hierarchyCopy = options.parseBoolOrTrue("hierarchyCopy")
       )
   }
 }

--- a/ksp/src/main/kotlin/fp/serrano/kopykat/KopyKatProcessor.kt
+++ b/ksp/src/main/kotlin/fp/serrano/kopykat/KopyKatProcessor.kt
@@ -28,6 +28,11 @@ internal class KopyKatProcessor(
 
   private fun KSClassDeclaration.process() {
     when {
+      options.hierarchyCopy && isSealedDataHierarchy() -> {
+        HierarchyCopyFunctionKt.writeTo(codegen)
+        if (options.copyMap) CopyMapFunctionKt.writeTo(codegen)
+        if (options.mutableCopy) MutableCopyKt.writeTo(codegen)
+      }
       isDataClass() -> {
         if (options.copyMap) CopyMapFunctionKt.writeTo(codegen)
         if (options.mutableCopy) MutableCopyKt.writeTo(codegen)
@@ -39,8 +44,3 @@ internal class KopyKatProcessor(
   }
 }
 
-private fun KSClassDeclaration.isDataClass() =
-  Modifier.DATA in modifiers && primaryConstructor != null
-
-private fun KSClassDeclaration.isValueClass() =
-  Modifier.VALUE in modifiers && primaryConstructor != null

--- a/ksp/src/main/kotlin/fp/serrano/kopykat/MutableCopy.kt
+++ b/ksp/src/main/kotlin/fp/serrano/kopykat/MutableCopy.kt
@@ -42,10 +42,11 @@ internal val KSClassDeclaration.MutableCopyKt: FileSpec
         addModifiers(KModifier.INLINE)
         addParameter(name = "block", type = LambdaTypeName.get(receiver = mutableParameterized, returnType = UNIT))
         val assignments = properties.map { "${it.name} = ${it.name}" } + "old = this"
+        val returns = repeatOnSubclasses("copy(${properties.joinToString { "${it.name} = mutable.${it.name}" }})")
         addCode(
           """
         | val mutable = $mutableParameterized(${assignments.joinToString()}).apply(block)
-        | return $targetClassName(${properties.joinToString { "${it.name} = mutable.${it.name}" }})
+        | return $returns
         """.trimMargin()
         )
       }

--- a/ksp/src/main/kotlin/fp/serrano/kopykat/utils/ClassScope.kt
+++ b/ksp/src/main/kotlin/fp/serrano/kopykat/utils/ClassScope.kt
@@ -12,6 +12,7 @@ internal value class ClassScope(private val classDeclaration: KSClassDeclaration
   val targetTypeName get() = classDeclaration.simpleName.asString()
   val typeVariableNames get() = classDeclaration.typeParameters.map { it.toTypeVariableName() }
   val kopyKatFileName get() = "${targetTypeName}KopyKat"
+  val kopyKatMapFileName get() = "${targetTypeName}MapKopyKat"
   val annotationTypeName get() = "${targetTypeName}CopyDslMarker"
   val annotationClassName get() = ClassName(packageName, annotationTypeName)
   val mutableTypeName get() = "Mutable$targetTypeName"

--- a/ksp/src/main/kotlin/fp/serrano/kopykat/utils/ClassUtils.kt
+++ b/ksp/src/main/kotlin/fp/serrano/kopykat/utils/ClassUtils.kt
@@ -1,0 +1,16 @@
+@file:Suppress("WildcardImport")
+package fp.serrano.kopykat.utils
+
+import com.google.devtools.ksp.*
+import com.google.devtools.ksp.symbol.*
+
+internal fun KSClassDeclaration.isDataClass() =
+  Modifier.DATA in modifiers && primaryConstructor != null
+
+internal fun KSClassDeclaration.isValueClass() =
+  Modifier.VALUE in modifiers && primaryConstructor != null
+
+internal fun KSClassDeclaration.isSealedDataHierarchy() =
+  Modifier.SEALED in modifiers
+          && isAbstract()
+          && getSealedSubclasses().all { it.isDataClass() }

--- a/ksp/src/test/kotlin/fp/serrano/kopykat/HierarchyCopyTest.kt
+++ b/ksp/src/test/kotlin/fp/serrano/kopykat/HierarchyCopyTest.kt
@@ -1,0 +1,56 @@
+package fp.serrano.kopykat
+
+import org.junit.jupiter.api.Test
+
+class HierarchyCopyTest {
+  @Test
+  fun `execute on one element`() {
+    """
+      |sealed abstract class User(open val name: String)
+      |data class Person(override val name: String, val age: Int): User(name)
+      |data class Company(override val name: String, val address: String): User(name)
+      |
+      |val p1: User = Person("Alex", 1)
+      |val p2 = p1.copy(name = "Pepe")
+      |val r = (p2 as Person).name
+      """.evals("r" to "Pepe")
+  }
+
+  @Test
+  fun `mutable on one element`() {
+    """
+      |sealed abstract class User(open val name: String)
+      |data class Person(override val name: String, val age: Int): User(name)
+      |data class Company(override val name: String, val address: String): User(name)
+      |
+      |val p1: User = Person("Alex", 1)
+      |val p2 = p1.copy { name = "Pepe" }
+      |val r = (p2 as Person).name
+      """.evals("r" to "Pepe")
+  }
+
+  @Test
+  fun `execute map on one element`() {
+    """
+      |sealed abstract class User(open val name: String)
+      |data class Person(override val name: String, val age: Int): User(name)
+      |data class Company(override val name: String, val address: String): User(name)
+      |
+      |val p1: User = Person("Alex", 1)
+      |val p2 = p1.copyMap(name = { it.lowercase() })
+      |val r = (p2 as Person).name
+      """.evals("r" to "alex")
+  }
+
+  @Test
+  fun `field which is not everywhere`() {
+    """
+      |sealed abstract class User(open val name: String)
+      |data class Person(override val name: String, val age: Int): User(name)
+      |data class Company(override val name: String, val address: String): User(name)
+      |
+      |val p1: User = Person("Alex", 1)
+      |val p2 = p1.copy(age = 2)
+      """.failsWith { it.contains("Cannot find a parameter with this name: age") }
+  }
+}


### PR DESCRIPTION
Fixes #4. Note that the properties must be declared as `open` in the parent class for this to work. I've upgraded all the functions to work with these hierarchies by introducing a `repeatOnSubclasses` helper method.

```kotlin
sealed abstract class User(open val name: String)
data class Person(override val name: String, val age: Int): User(name)
data class Company(override val name: String, val address: String): User(name)

fun User.takeOver() = copy { name = "Me" }
```